### PR TITLE
Exit if registry can't be created.

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,6 +84,7 @@ func main() {
 	registry, err := registryserver.NewPluginRegistry(endpoint)
 	if err != nil {
 		setupLog.Error(err, "plugin registry failure")
+		os.Exit(1)
 	}
 
 	registry.Start()


### PR DESCRIPTION
Exit cleanly instead of segfaulting if registry can't be created.