### PR TITLE
Dockerfile: move out of distroless/base-debian11 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN mkdir -p /usr/local/share/package-licenses \
   && cp /usr/local/go/LICENSE /usr/local/share/package-licenses/go.LICENSE \
   && cp LICENSE /usr/local/share/package-licenses/trusted-attestation-controller.LICENSE
 
-FROM gcr.io/distroless/base-debian11
+FROM gcr.io/distroless/base
 
 WORKDIR /
 COPY --from=builder /manager .


### PR DESCRIPTION
instead, use distroless/base image. Debian image is using glibc version (glibc/libc6@2.31-13+deb11u3) which has known vulnerabilities.