### PR TITLE
Null plugin for TAC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ COPY main.go main.go
 
 RUN GOOS=linux GOARCH=amd64 go build -a -o manager /main.go
 RUN GOOS=linux GOARCH=amd64 go build -a -o kmra-plugin /plugins/kmra/main.go
+RUN GOOS=linux GOARCH=amd64 go build -a -o null-plugin /plugins/null/main.go
 RUN mkdir -p /usr/local/share/package-licenses \
   && cp /usr/local/go/LICENSE /usr/local/share/package-licenses/go.LICENSE \
   && cp LICENSE /usr/local/share/package-licenses/trusted-attestation-controller.LICENSE
@@ -22,6 +23,7 @@ FROM gcr.io/distroless/base
 WORKDIR /
 COPY --from=builder /manager .
 COPY --from=builder /kmra-plugin .
+COPY --from=builder /null-plugin .
 COPY --from=builder /usr/local/share/package-licenses /usr/local/share/package-licenses
 USER 5000:5000
 ENTRYPOINT ["/manager"]

--- a/plugins/null/README.md
+++ b/plugins/null/README.md
@@ -1,0 +1,7 @@
+# Null-plugin
+
+TAC deployment defaults to this plugin if other plugins are not specified. 
+This is to avoid infinite crashing loop when trying to test without a keyserver.
+
+It requires nothing and does nothing, just registers with the manager and keeps the container running next to the manager.
+

--- a/plugins/null/main.go
+++ b/plugins/null/main.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"time"
+
+	"github.com/go-logr/logr"
+	pluginapi "github.com/intel/trusted-attestation-controller/pkg/api/v1alpha1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"k8s.io/klog/v2/klogr"
+)
+
+func main() {
+	var pluginName string
+	var socketPath string
+	// var registrationPath string
+	var controllerEndpoint string
+	flag.StringVar(&pluginName, "plugin-name", "null", "Name of the plugin.")
+	flag.StringVar(&socketPath, "plugin-socket-path", "/null.sock", "The address the key server binds to.")
+	flag.StringVar(&controllerEndpoint, "registry-socket-path", "/registration/controller.sock", "Plugin registration server socket path.")
+	flag.Parse()
+
+	l := klogr.New().WithName("setup")
+
+	l.Info("Initializing the null plugin...")
+
+	ctx, cancelRegistration := context.WithCancel(context.TODO())
+	success := registerPlugin(ctx, l, pluginName, socketPath, controllerEndpoint)
+	if success {
+		// Keep the container running and do nothing
+		for {
+			l.Info("Infinite looping...")
+			time.Sleep(time.Minute)
+		}
+	}
+
+	cancelRegistration()
+}
+
+func registerPlugin(ctx context.Context, l logr.Logger, pluginName, socketPath, controllerSocketPath string) bool {
+	success := false
+	retryTimeout := time.Minute
+	var conn *grpc.ClientConn
+	for {
+		var err error
+		if conn != nil && conn.GetState() == connectivity.Ready {
+			break
+		}
+		l.Info("Connecting to registry server...", "at", controllerSocketPath)
+		conn, err = grpc.DialContext(ctx, "unix://"+controllerSocketPath, grpc.WithInsecure(), grpc.WithBlock())
+		if err != nil {
+			l.V(4).Error(err, "Failed to connect controller socket, will retry", "after", retryTimeout)
+			time.Sleep(retryTimeout)
+			continue
+		}
+	}
+	defer conn.Close()
+	client := pluginapi.NewRegistryClient(conn)
+	for {
+		if success {
+			return true
+		}
+		l.Info("Registering the plugin...", "name", pluginName, "socket", socketPath)
+		_, err := client.RegisterPlugin(ctx, &pluginapi.RegisterPluginRequest{
+			Name:    pluginName,
+			Address: socketPath,
+		})
+		if err != nil {
+			l.V(3).Error(err, "Failed to register plugin socket, will retry", "after", retryTimeout)
+			time.Sleep(retryTimeout)
+			continue
+		}
+		l.Info("Registration success")
+		success = true
+	}
+}


### PR DESCRIPTION
Summary of changes:
- Created a new plugin called "null-plugin" to avoid key server certification stuff while testing.
- The null plugin registers with the manager and if it registers successfully then it starts looping and keeps the container alive.
- Modified Dockerfile to build null-plugin.